### PR TITLE
Language blocks as table/dl via AsciiDoc, removing problematic flags

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,41 +1,29 @@
-# anim-com
+anim-com
+========
 
-## Translations
+== Translations
 
-The translation of our platform is managed on [Crowdin](https://crwd.in/exodus-privacy)
+The translation of our platform is managed on https://crwd.in/exodus-privacy[Crowdin]
 
-## Videos
+== Videos
 
-### 🇬🇧 EN
-
+[horizontal]
+[#video-en]*[en]* English::
 This repository is used for the external communication from Exodus Privacy.
-
 You will find the videos and more important, the subtitle files (in the folders `vidéos/xxx`).
-
 If you want to help us to improve our subtitles or add your native language, do not hesitate, your contributions are welcome.
+If you have a nice voice and are ready to dub those videos, once again, you’re welcome.
+Fork this repo and ‘just do it’.
 
-If you have a nice voice and are ready to dubb those videos, once again, you're welcome.
-
-Fork this repo and just do it.
-
-### 🇫🇷 FR
-
+[#video-fr]*[fr]* Français::
 Ce dépôt sert à la communication externe d'Exodus Privacy.
-
 Vous y trouverez les vidéos et, plus important, les fichiers de sous-titres (dans les dossiers `vidéos/xxxx`).
-
 Si vous avez une belle voix et l'envie de doubler les vidéos, votre aide est la bienvenue.
-
 « Forkez » le dépôt et amusez-vous bien.
 
-### 🇩🇪 DE
-
+[#video-de]*[de]* Deutsch::
 Dieses Repository wird für die externe Kommunikation von Exodus Privacy benutzt.
-
 Die Videos und viel wichtiger die Untertitel Dateien findest du in (`vidéos/xxx` Verzeichnis).
-
 Wenn du uns helfen möchtest, unsere Untertitel zu verbessen oder deine Muttersprache hinzuzufügen, zögere nicht, dein Beitrag ist stets willkommen.
-
 Wenn du eine nette Stimme hast und bereit bist diese Videos zu synchronisieren, nur zu.
-
-Fork dir dieses Repo und "just do it".
+Fork dir dieses Repo und „just do it“.


### PR DESCRIPTION
[Flags are not languages](http://www.flagsarenotlanguages.com/). To remove this problematic issue, I moved the list to a horizontal definition list (which is rendered as a table). I tried using some other formatting options but most were not compatible with GitHub's default styling. I think this provides the best alternative while still maintaining IDs. Unfortunately `lang` attributes are stripped or I'd wrap the whole block to help with the accessibility. To view a preview of this commit rendered in GitHub: https://github.com/toastal/anim-com/blob/lang-blocks%2Bno-flags/README.adoc.

Additionally, I added proper curly punctuation to English and German.